### PR TITLE
Make omni.py compliant with numpy v1.12

### DIFF
--- a/src/omni.py
+++ b/src/omni.py
@@ -95,7 +95,7 @@ def aa_to_info(aa, pols=['x'], fcal=False, **kwargs):
         for z, pol in enumerate(pols):
             z = 2**z
             i = Antpol(ant, pol, len(aa))
-            antpos[i,0], antpos[i,1], antpos[i,2] = x,y,z
+            antpos[int(i),0], antpos[int(i),1], antpos[int(i),2] = x,y,z
     reds = compute_reds(nant, pols, antpos[:nant], tol=.1)
     ex_ants = [Antpol(i,nant).ant() for i in range(antpos.shape[0]) if antpos[i,0] == -1]
     kwargs['ex_ants'] = kwargs.get('ex_ants',[]) + ex_ants
@@ -127,7 +127,7 @@ def aa_pos_to_info(aa, pols=['x'], **kwargs):
         for z,pol in enumerate(pols):
             z = 2**z # exponential ensures diff xpols aren't redundant w/ each other
             i = Antpol(ant,pol,len(aa)) # creates index in POLNUM/NUMPOL for pol
-            antpos[i,0],antpos[i,1],antpos[i,2] = x,y,z
+            antpos[int(i),0],antpos[int(i),1],antpos[int(i),2] = x,y,z
     reds = compute_reds(nant, pols, antpos[:nant],tol=0.0001) # only first nant b/c compute_reds treats pol redundancy separately
     # XXX haven't enforced xy = yx yet.  need to conjoin red groups for that
     ex_ants = [Antpol(i,nant).ant() for i in range(antpos.shape[0]) if antpos[i,0] < 0]


### PR DESCRIPTION
numpy v1.12 no longer implicitly calls int() on object instances when used as an array index and instead raises and error. In my testing, these changes now make the code run with numpy v1.12.1